### PR TITLE
use idw to fill small and large holes in 2 passes

### DIFF
--- a/binning.h
+++ b/binning.h
@@ -138,8 +138,10 @@ inline void binning(pcl::shared_ptr<pcl::PointCloud<PointT>> &cloud,
         /* fill small holes */
         fill_idw(sum_array, n_array, interp_array, cellhd.rows, cellhd.cols, 1, method, weights_matrix);
 
-        /* fill big holes */
-        fill_idw(sum_array, n_array, interp_array, cellhd.rows, cellhd.cols, 5, method, weights_matrix);
+        /* fill holes of max size 3 cm */
+        int fill_size = (int) (0.015 / resolution);
+        if (fill_size)
+            fill_idw(sum_array, n_array, interp_array, cellhd.rows, cellhd.cols, fill_size, method, weights_matrix);
     }
     /* calc stats and output */
     G_message(_("Writing to map ..."));

--- a/main.cpp
+++ b/main.cpp
@@ -733,6 +733,14 @@ int main(int argc, char **argv)
     Points = Vect_new_line_struct();
     Cats = Vect_new_cats_struct();
 
+    // weights for binning IDW interpolation
+    // size must be max 50
+    int max_weight_size = 50;
+    double **weights = (double **)G_malloc(sizeof(double *) * max_weight_size);
+    for (int i = 0; i < max_weight_size; i++) {
+        weights[i] = (double *)G_malloc(sizeof(double) * max_weight_size);
+    }
+
     pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZRGB>());
 
     struct bound_box bbox;
@@ -949,7 +957,8 @@ int main(int argc, char **argv)
         if (routput) {
             if (strcmp(method, "interpolation") != 0) {
                 binning(cloud, routput, &bbox, resolution,
-                        scale, zexag, region3D ? -zrange_max : bbox.B, offset, method);
+                        scale, zexag, region3D ? -zrange_max : bbox.B, offset, method,
+                        weights);
             }
             Rast_get_cellhd(routput, "", &cellhd);
             // georeference horizontally
@@ -1014,6 +1023,9 @@ int main(int argc, char **argv)
     }
 
     k4a.shut_down();
+    for (int i = 0; i < max_weight_size; i++)
+        G_free(weights[i]);
+    G_free(weights);
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Adds IDW interpolation to binning, replaces spline interpolation. It goes through 2 passes of IDW to fill small and big holes.

`r.in.kinect  method=interpolation interpolation=idw ...` results in binning with holes filled with IDW.
`r.in.kinect  method=interpolation interpolation=splines ...` results in interpolation from points using RST library.
`r.in.kinect  method=mean ...` results in binning only (contains no data).

Default interpolation is IDW.

The window size for interpolating bigger holes depends on the scanning resolution and is set to fill holes approximately 3 cm big and smaller.

The binning + IDW method is generally faster and doesn't create segment artifacts comparing to RST.